### PR TITLE
attempt to fix the timeline image rendering issue

### DIFF
--- a/src/components/timeline/TimeLine.tsx
+++ b/src/components/timeline/TimeLine.tsx
@@ -122,9 +122,15 @@ const TimeLine = () => {
       </div>
       <Modal
         className="custom-modal"
+        key={selected?.date}
+        destroyOnHidden
         centered
         open={isOpen}
         onOk={closeModal}
+        okButtonProps={{
+          className: "got-it-btn",
+        }}
+        okText="Lookin Good!"
         closable={false}
         cancelButtonProps={{ style: { display: "none" } }}
       >


### PR DESCRIPTION
when you open the image modal, the previous image appears for a split second instead of the current image